### PR TITLE
Adjust socket interfaces to use common predicates

### DIFF
--- a/avahi.te
+++ b/avahi.te
@@ -8,6 +8,7 @@ policy_module(avahi, 1.15.0)
 type avahi_t;
 type avahi_exec_t;
 init_daemon_domain(avahi_t, avahi_exec_t)
+init_named_socket_activation(avahi_t, avahi_var_run_t)
 
 type avahi_initrc_exec_t;
 init_script_file(avahi_initrc_exec_t)

--- a/avahi.te
+++ b/avahi.te
@@ -7,7 +7,7 @@ policy_module(avahi, 1.15.0)
 
 type avahi_t;
 type avahi_exec_t;
-init_socket_daemon_domain(avahi_t, avahi_exec_t, avahi_var_run_t)
+init_daemon_domain(avahi_t, avahi_exec_t)
 
 type avahi_initrc_exec_t;
 init_script_file(avahi_initrc_exec_t)

--- a/avahi.te
+++ b/avahi.te
@@ -7,7 +7,7 @@ policy_module(avahi, 1.15.0)
 
 type avahi_t;
 type avahi_exec_t;
-init_daemon_domain(avahi_t, avahi_exec_t)
+init_socket_daemon_domain(avahi_t, avahi_exec_t, avahi_var_run_t)
 
 type avahi_initrc_exec_t;
 init_script_file(avahi_initrc_exec_t)

--- a/brctl.te
+++ b/brctl.te
@@ -42,5 +42,5 @@ miscfiles_read_localization(brctl_t)
 
 optional_policy(`
 	xen_append_log(brctl_t)
-	xen_dontaudit_rw_unix_stream_sockets(brctl_t)
+	xen_dontaudit_rw_stream_sockets(brctl_t)
 ')

--- a/cups.te
+++ b/cups.te
@@ -14,7 +14,7 @@ files_pid_file(cupsd_config_var_run_t)
 
 type cupsd_t;
 type cupsd_exec_t;
-init_daemon_domain(cupsd_t, cupsd_exec_t)
+init_socket_daemon_domain(cupsd_t, cupsd_exec_t, cupsd_var_run_t)
 mls_trusted_object(cupsd_t)
 
 type cupsd_etc_t;

--- a/cups.te
+++ b/cups.te
@@ -15,6 +15,7 @@ files_pid_file(cupsd_config_var_run_t)
 type cupsd_t;
 type cupsd_exec_t;
 init_daemon_domain(cupsd_t, cupsd_exec_t)
+init_named_socket_activation(cupsd_t, cupsd_var_run_t)
 mls_trusted_object(cupsd_t)
 
 type cupsd_etc_t;

--- a/cups.te
+++ b/cups.te
@@ -14,7 +14,7 @@ files_pid_file(cupsd_config_var_run_t)
 
 type cupsd_t;
 type cupsd_exec_t;
-init_socket_daemon_domain(cupsd_t, cupsd_exec_t, cupsd_var_run_t)
+init_daemon_domain(cupsd_t, cupsd_exec_t)
 mls_trusted_object(cupsd_t)
 
 type cupsd_etc_t;

--- a/dbus.te
+++ b/dbus.te
@@ -31,7 +31,7 @@ typealias session_dbusd_tmp_t alias { auditadm_dbusd_tmp_t secadm_dbusd_tmp_t };
 userdom_user_tmp_file(session_dbusd_tmp_t)
 
 type system_dbusd_t;
-init_socket_daemon_domain(system_dbusd_t, dbusd_exec_t, system_dbusd_var_run_t)
+init_system_domain(system_dbusd_t, dbusd_exec_t)
 
 type system_dbusd_tmp_t;
 files_tmp_file(system_dbusd_tmp_t)

--- a/dbus.te
+++ b/dbus.te
@@ -32,6 +32,7 @@ userdom_user_tmp_file(session_dbusd_tmp_t)
 
 type system_dbusd_t;
 init_system_domain(system_dbusd_t, dbusd_exec_t)
+init_named_socket_activation(system_dbusd_t, system_dbusd_var_run_t)
 
 type system_dbusd_tmp_t;
 files_tmp_file(system_dbusd_tmp_t)

--- a/dbus.te
+++ b/dbus.te
@@ -31,7 +31,7 @@ typealias session_dbusd_tmp_t alias { auditadm_dbusd_tmp_t secadm_dbusd_tmp_t };
 userdom_user_tmp_file(session_dbusd_tmp_t)
 
 type system_dbusd_t;
-init_system_domain(system_dbusd_t, dbusd_exec_t)
+init_socket_daemon_domain(system_dbusd_t, dbusd_exec_t, system_dbusd_var_run_t)
 
 type system_dbusd_tmp_t;
 files_tmp_file(system_dbusd_tmp_t)

--- a/iscsi.te
+++ b/iscsi.te
@@ -8,6 +8,7 @@ policy_module(iscsi, 1.9.0)
 type iscsid_t;
 type iscsid_exec_t;
 init_daemon_domain(iscsid_t, iscsid_exec_t)
+init_abstract_socket_activation(iscsid_t)
 
 type iscsi_initrc_exec_t;
 init_script_file(iscsi_initrc_exec_t)

--- a/nscd.te
+++ b/nscd.te
@@ -135,6 +135,6 @@ optional_policy(`
 ')
 
 optional_policy(`
-	xen_dontaudit_rw_unix_stream_sockets(nscd_t)
+	xen_dontaudit_rw_stream_sockets(nscd_t)
 	xen_append_log(nscd_t)
 ')

--- a/postfix.te
+++ b/postfix.te
@@ -621,7 +621,7 @@ optional_policy(`
 ')
 
 optional_policy(`
-	sendmail_rw_unix_stream_sockets(postfix_postdrop_t)
+	sendmail_rw_stream_sockets(postfix_postdrop_t)
 ')
 
 optional_policy(`

--- a/procmail.te
+++ b/procmail.te
@@ -134,7 +134,7 @@ optional_policy(`
 	sendmail_domtrans(procmail_t)
 	sendmail_signal(procmail_t)
 	sendmail_dontaudit_rw_tcp_sockets(procmail_t)
-	sendmail_dontaudit_rw_unix_stream_sockets(procmail_t)
+	sendmail_dontaudit_rw_stream_sockets(procmail_t)
 ')
 
 optional_policy(`

--- a/rpcbind.te
+++ b/rpcbind.te
@@ -7,7 +7,7 @@ policy_module(rpcbind, 1.7.1)
 
 type rpcbind_t;
 type rpcbind_exec_t;
-init_daemon_domain(rpcbind_t, rpcbind_exec_t)
+init_socket_daemon_domain(rpcbind_t, rpcbind_exec_t, rpcbind_var_run_t)
 
 type rpcbind_initrc_exec_t;
 init_script_file(rpcbind_initrc_exec_t)

--- a/rpcbind.te
+++ b/rpcbind.te
@@ -8,6 +8,7 @@ policy_module(rpcbind, 1.7.1)
 type rpcbind_t;
 type rpcbind_exec_t;
 init_daemon_domain(rpcbind_t, rpcbind_exec_t)
+init_named_socket_activation(rpcbind_t, rpcbind_var_run_t)
 
 type rpcbind_initrc_exec_t;
 init_script_file(rpcbind_initrc_exec_t)

--- a/rpcbind.te
+++ b/rpcbind.te
@@ -7,7 +7,7 @@ policy_module(rpcbind, 1.7.1)
 
 type rpcbind_t;
 type rpcbind_exec_t;
-init_socket_daemon_domain(rpcbind_t, rpcbind_exec_t, rpcbind_var_run_t)
+init_daemon_domain(rpcbind_t, rpcbind_exec_t)
 
 type rpcbind_initrc_exec_t;
 init_script_file(rpcbind_initrc_exec_t)

--- a/sendmail.if
+++ b/sendmail.if
@@ -142,7 +142,7 @@ interface(`sendmail_dontaudit_rw_tcp_sockets',`
 ########################################
 ## <summary>
 ##	Read and write sendmail unix
-##	domain stream sockets.
+##	domain stream sockets. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -155,7 +155,47 @@ interface(`sendmail_rw_unix_stream_sockets',`
 		type sendmail_t;
 	')
 
+	refpolicywarn(`$0($1) has been deprecated, please use sendmail_rw_stream_sockets() instead.')
+	sendmail_rw_stream_sockets($1)
+')
+
+########################################
+## <summary>
+##	Read and write sendmail unix
+##	domain stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sendmail_rw_stream_sockets',`
+	gen_require(`
+		type sendmail_t;
+	')
+
 	allow $1 sendmail_t:unix_stream_socket rw_socket_perms;
+')
+
+########################################
+## <summary>
+##	Read and write sendmail unix
+##	domain stream sockets. (Deprecated)
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`sendmail_dontaudit_rw_unix_stream_sockets',`
+	gen_require(`
+		type sendmail_t;
+	')
+
+	refpolicywarn(`$0($1) has been deprecated, please use sendmail_dontaudit_rw_stream_sockets() instead.')
+	sendmail_dontaudit_rw_stream_sockets($1)
 ')
 
 ########################################
@@ -169,7 +209,7 @@ interface(`sendmail_rw_unix_stream_sockets',`
 ##	</summary>
 ## </param>
 #
-interface(`sendmail_dontaudit_rw_unix_stream_sockets',`
+interface(`sendmail_dontaudit_rw_stream_sockets',`
 	gen_require(`
 		type sendmail_t;
 	')

--- a/uucp.te
+++ b/uucp.te
@@ -165,5 +165,5 @@ miscfiles_read_localization(uux_t)
 optional_policy(`
 	mta_send_mail(uux_t)
 	mta_read_queue(uux_t)
-	sendmail_dontaudit_rw_unix_stream_sockets(uux_t)
+	sendmail_dontaudit_rw_stream_sockets(uux_t)
 ')

--- a/xen.if
+++ b/xen.if
@@ -198,7 +198,7 @@ interface(`xen_read_xenstored_pid_files',`
 ########################################
 ## <summary>
 ##	Do not audit attempts to read and write
-##	Xen unix domain stream sockets.
+##	Xen unix domain stream sockets. (Deprecated)
 ## </summary>
 ## <param name="domain">
 ##	<summary>
@@ -207,6 +207,26 @@ interface(`xen_read_xenstored_pid_files',`
 ## </param>
 #
 interface(`xen_dontaudit_rw_unix_stream_sockets',`
+	gen_require(`
+		type xend_t;
+	')
+
+	refpolicywarn(`$0($1) has been deprecated, please use xen_dontaudit_rw_stream_sockets() instead.')
+	xen_dontaudit_rw_stream_sockets($1)
+')
+
+########################################
+## <summary>
+##	Do not audit attempts to read and write
+##	Xen unix domain stream sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain to not audit.
+##	</summary>
+## </param>
+#
+interface(`xen_dontaudit_rw_stream_sockets',`
 	gen_require(`
 		type xend_t;
 	')


### PR DESCRIPTION
refpolicy style dictates that we use the following naming scheme:
modulename[_modifier]_verb_predicate()

"stream" is the commonly used predicate for unix_stream_socket
"dgram" is the commonly used predicate for unix_dgram_socket

Fix these interfaces and deprecate their older versions